### PR TITLE
bug: add width limit on KvToolTip

### DIFF
--- a/src/components/KvInput/index.tsx
+++ b/src/components/KvInput/index.tsx
@@ -48,6 +48,7 @@ const KvInput = React.forwardRef<HTMLInputElement, TKvInput>(
           content={tooltipProps?.content}
           open={tooltipProps?.status === "invalid" && !!tooltipProps?.content}
           status={tooltipProps?.status}
+          maxWidthAsChild
           {...tooltipProps}
         >
           <input className={computedClasses} type="text" ref={ref} {...props} />

--- a/src/components/KvSeal/styles.module.scss
+++ b/src/components/KvSeal/styles.module.scss
@@ -20,7 +20,7 @@
   }
 
   & svg {
-    width: var(--icon-size);
+    min-width: var(--icon-size);
     height: var(--icon-size);
     color: var(--kv-seal-icon-color-inverted, #fff);
   }
@@ -49,7 +49,7 @@
     --kv-seal-background: var(--kv-color-lychee-600);
     --kv-seal-icon-color: var(--kv-color-lychee-600);
   }
-  
+
   &--inverted {
     --kv-seal-background: var(--kv-color-lychee-100);
     --kv-seal-icon-color-inverted: var(--kv-seal-icon-color);

--- a/src/components/KvTooltip/index.tsx
+++ b/src/components/KvTooltip/index.tsx
@@ -1,3 +1,5 @@
+import React, { useEffect, useRef, useState } from "react";
+
 import * as Tooltip from "@radix-ui/react-tooltip";
 import { TooltipContentProps } from "@radix-ui/react-tooltip";
 import { KvSeal } from "../KvSeal";
@@ -10,6 +12,7 @@ export type TKvTooltip = {
   onOpenChange?: () => void;
   status?: "idle" | "invalid";
   hasPortal?: boolean;
+  maxWidthAsChild?: boolean;
 } & TooltipContentProps &
   React.PropsWithChildren;
 
@@ -23,21 +26,51 @@ export function KvTooltip({
   side = "top",
   status = "idle",
   hasPortal = true,
+  maxWidthAsChild = true,
   ...props
 }: TKvTooltip) {
+  const triggerRef = useRef<HTMLElement | null>(null);
+  const [triggerWidth, setTriggerWidth] = useState<number | null>(null);
+
+  useEffect(() => {
+    if (!maxWidthAsChild) {
+      return;
+    }
+
+    if (triggerRef.current) {
+      const updateWidth = () => {
+        setTriggerWidth(triggerRef.current?.offsetWidth || null);
+      };
+
+      updateWidth();
+
+      const resizeObserver = new ResizeObserver(updateWidth);
+      resizeObserver.observe(triggerRef.current);
+
+      return () => resizeObserver.disconnect();
+    }
+  }, [maxWidthAsChild]);
+
   const renderContent = () => {
     const contentTemplate = (
       <Tooltip.Content
-        className={`${styles["kv-tooltip__content"]} ${status === "invalid" && styles["kv-tooltip__content--error"]}`}
+        className={`${styles["kv-tooltip__content"]} ${
+          status === "invalid" && styles["kv-tooltip__content--error"]
+        }`}
         align={align}
         sideOffset={status === "invalid" ? -12 : 4}
         side={side}
+        style={{
+          maxWidth: maxWidthAsChild ? triggerWidth ?? "auto" : "auto",
+        }}
         {...props}
       >
         {status === "invalid" && <KvSeal variant="error" size="small" />}
         {content}
         <Tooltip.Arrow
-          className={`${styles["kv-tooltip__arrow"]} ${status === "invalid" && styles["kv-tooltip__arrow--error"]}`}
+          className={`${styles["kv-tooltip__arrow"]} ${
+            status === "invalid" && styles["kv-tooltip__arrow--error"]
+          }`}
           height={8}
           width={16}
         />
@@ -59,7 +92,11 @@ export function KvTooltip({
         defaultOpen={defaultOpen}
         onOpenChange={onOpenChange}
       >
-        <Tooltip.Trigger asChild>{children}</Tooltip.Trigger>
+        <Tooltip.Trigger asChild>
+          {React.cloneElement(children as React.ReactElement, {
+            ref: triggerRef,
+          })}
+        </Tooltip.Trigger>
         {renderContent()}
       </Tooltip.Root>
     </Tooltip.Provider>

--- a/src/components/KvTooltip/index.tsx
+++ b/src/components/KvTooltip/index.tsx
@@ -26,7 +26,7 @@ export function KvTooltip({
   side = "top",
   status = "idle",
   hasPortal = true,
-  maxWidthAsChild = true,
+  maxWidthAsChild = false,
   ...props
 }: TKvTooltip) {
   const triggerRef = useRef<HTMLElement | null>(null);

--- a/src/components/KvTooltip/styles.module.scss
+++ b/src/components/KvTooltip/styles.module.scss
@@ -2,8 +2,8 @@
   display: flex;
   gap: 0.5rem;
   align-items: center;
-  border-radius: 2em;
-  padding: 0.25rem 0.5rem;
+  border-radius: 0.5rem;
+  padding: 0.5rem;
   font-size: var(--kv-font-size-sm);
   font-weight: 500;
   line-height: 1;


### PR DESCRIPTION
O tooltip de erro em campos, quando exibido em um modal, se o campo estiver no canto direito, fica cortado.