### PR TITLE
fix(loading): SSR-safe lottie Player (fixes document-is-not-defined on server render)

### DIFF
--- a/components/KvLoading/KvLoader.tsx
+++ b/components/KvLoading/KvLoader.tsx
@@ -1,7 +1,14 @@
 "use client";
 
-import { Player } from "@lottiefiles/react-lottie-player";
+import dynamic from "next/dynamic";
 import loadingSrc from "./loading-borboleta.json";
+
+// Client-side only: lottie's bundled goober touches `document` at import time and
+// throws during SSR. Mirrors the proven ButterflyLoading pattern.
+const Player = dynamic(
+  () => import("@lottiefiles/react-lottie-player").then((mod) => mod.Player),
+  { ssr: false },
+);
 
 export const KvLoader = () => {
   return (

--- a/components/KvSpinner/index.tsx
+++ b/components/KvSpinner/index.tsx
@@ -1,10 +1,18 @@
 "use client";
 
-import { Player } from "@lottiefiles/react-lottie-player";
+import dynamic from "next/dynamic";
 
 import { KeyColors } from "../../types/styles";
 import loadingPurple from "./loading-button-purple.json";
 import loadingWhite from "./loading-button-white.json";
+
+// Load lottie client-side only: its bundled goober reaches for `document` at import
+// time and throws "document is not defined" during SSR (Next renders Client Components
+// on the server too). Mirrors the proven ButterflyLoading pattern.
+const Player = dynamic(
+  () => import("@lottiefiles/react-lottie-player").then((mod) => mod.Player),
+  { ssr: false },
+);
 
 export const KvSpinner = ({ color }: { color?: KeyColors }) => {
   return (

--- a/src/components/KvLoading/KvLoader.tsx
+++ b/src/components/KvLoading/KvLoader.tsx
@@ -1,7 +1,14 @@
 "use client";
 
-import { Player } from "@lottiefiles/react-lottie-player";
+import dynamic from "next/dynamic";
 import loadingSrc from "./loading-borboleta.json";
+
+// Client-side only: lottie's bundled goober touches `document` at import time and
+// throws during SSR. Mirrors the ButterflyLoading pattern.
+const Player = dynamic(
+  () => import("@lottiefiles/react-lottie-player").then((mod) => mod.Player),
+  { ssr: false },
+);
 
 export const KvLoader = () => {
   return (

--- a/src/components/KvSpinner/index.tsx
+++ b/src/components/KvSpinner/index.tsx
@@ -1,10 +1,17 @@
 "use client";
 
-import { Player } from "@lottiefiles/react-lottie-player";
+import dynamic from "next/dynamic";
 
 import { KeyColors } from "../../types/styles";
 import loadingPurple from "./loading-button-purple.json";
 import loadingWhite from "./loading-button-white.json";
+
+// Load lottie client-side only: its bundled goober reaches for `document` at import
+// time and throws "document is not defined" during SSR. Mirrors the ButterflyLoading pattern.
+const Player = dynamic(
+  () => import("@lottiefiles/react-lottie-player").then((mod) => mod.Player),
+  { ssr: false },
+);
 
 export const KvSpinner = ({ color }: { color?: KeyColors }) => {
   return (


### PR DESCRIPTION
## SSR-safe lottie loading

`@lottiefiles/react-lottie-player` bundles **goober**, which reaches for `document`
at **import time**. When a consuming Next.js app server-renders these Client Components
(Next evaluates `"use client"` modules during SSR too), the eager `import { Player }`
throws `ReferenceError: document is not defined` and **500s every route** that transitively
imports `KvButton` → `KvSpinner` (or `KvLoader`).

This defers the lottie import to the client via `next/dynamic(() => …, { ssr: false })` —
the exact pattern already used by consuming apps' own `ButterflyLoading`. The component
renders nothing on the server and mounts the animation on hydration (correct for a spinner).

Applied to **both** component trees shipped by this package:
- `components/KvSpinner/index.tsx`, `components/KvLoading/KvLoader.tsx`
- `src/components/KvSpinner/index.tsx`, `src/components/KvLoading/KvLoader.tsx`

Both trees are imported by Next apps (verified via runtime SSR traces in `kivid-credenciados`),
so both need the fix.

### Verification
In `kivid-credenciados` (Next 14), before: every page 500s with `document is not defined`.
After (pointing the submodule at this branch): `/`, `/login`, `/clientes`,
`/financeiro/recebimentos`, `/imprimir/*` all render **200** with no goober error.

### Note
These files carry `"use client"` and already assume a Next runtime, so `next/dynamic` is
consistent. No client-side visual change (same animation, same props).
